### PR TITLE
Transition to structural schema required in 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,6 @@ deploy:
     on:
       tags: true
       condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+_[0-9]{3}$
-  - provider: releases
-    file: /tmp/resource.yaml
-    skip_cleanup: true
-    draft: true
-    api_key:
-      secure: "${GITHUB_TOKEN}"
-    on:
-      tags: true
-      condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+_[0-9]{3}$
 
   # Deploy released builds
   - provider: script

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kubectl apply -f "https://github.com/razee-io/RemoteResource/releases/latest/dow
 ### Sample
 
 ```yaml
-apiVersion: "deploy.razee.io/v1alpha1"
+apiVersion: "deploy.razee.io/v1alpha2"
 kind: RemoteResource
 metadata:
   name: <remote_resource_name>

--- a/README.md
+++ b/README.md
@@ -35,46 +35,66 @@ spec:
         url: http://<source_repo_url>/<file_name2>
 ```
 
-### Required Fields
+### Spec
 
-- `.spec.requests`
-  - type: array
-  - items:
-    - type: object
-    - required: [[options](#Options)]
-    - optional: [[optional](#Optional)]
+**Path:** `.spec`
 
-## Features
+**Description:** `spec` is required and **must** include section `requests`.
 
-### Requests
+**Schema:**
 
-#### Options
+```yaml
+spec:
+  type: object
+  required: [requests]
+  properties:
+    requests:
+      type: array
+      ...
+```
 
-`.spec.requests.options`
+### Request Options
 
-All options defined in an options object will be passed as is to the http request.
-This means you can specify things like headers for authentication in this section.
-See [RemoteResourceS3](https://github.com/razee-io/RemoteResourceS3) for
-authenticating with an S3 object store.
+**Path:** `.spec.requests[].options`
 
-- Schema:
-  - type: object
-  - required: [url || uri]
-  - optional: [any other other options to be passed along with the request]
+**Description:** All options defined in an options object will be passed as-is
+to the http request. This means you can specify things like headers for
+authentication in this section. See [RemoteResourceS3](https://github.com/razee-io/RemoteResourceS3)
+for authenticating with an S3 object store.
 
-#### Optional
+**Schema:**
 
-`.spec.requests.optional`
+```yaml
+options:
+  type: object
+  oneOf:
+    - required: [url]
+    - required: [uri]
+  properties:
+    url:
+      type: string
+      format: uri
+    uri:
+      type: string
+      format: uri
+```
 
-- DEFAULT: `false`
-  - if download or applying child resource fails, RemoteResource will stop
-  execution and report error to `.status`.
-- `true`
-  - if download or applying child resource fails, RemoteResource will continue
-  processing the rest of the defined requests, and will report a warning to `.status`.
+### Optional Request
 
-- Schema:
-  - type: boolean
+**Path:** `.spec.requests[].optional`
+
+**Description:** if download or applying child resource fails, RemoteResource
+will stop execution and report error to `.status`. You can allow execution to
+continue by marking a reference as optional.
+
+**Schema:**
+
+```yaml
+optional:
+  type: boolean
+```
+
+**Default:** `false`
 
 ### Managed Resource Labels
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ options:
     uri:
       type: string
       format: uri
+    headers:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
 ```
 
 ### Optional Request

--- a/kubernetes/RemoteResource/resource.yaml
+++ b/kubernetes/RemoteResource/resource.yaml
@@ -128,6 +128,7 @@ items:
                         type: boolean
                       options:
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                         oneOf:
                           - required: [url]
                           - required: [uri]
@@ -138,3 +139,9 @@ items:
                           uri:
                             type: string
                             format: uri
+                          headers:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/kubernetes/RemoteResource/resource.yaml
+++ b/kubernetes/RemoteResource/resource.yaml
@@ -87,6 +87,11 @@ items:
           # Each version can be enabled/disabled by Served flag.
           served: true
           # One and only one version must be marked as the storage version.
+          storage: false
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
           storage: true
       # either Namespaced or Cluster
       scope: Namespaced
@@ -106,6 +111,8 @@ items:
       validation:
         # openAPIV3Schema is the schema for validating custom objects.
         openAPIV3Schema:
+          type: object
+          required: [spec]
           properties:
             spec:
               type: object
@@ -115,39 +122,19 @@ items:
                   type: array
                   items:
                     type: object
+                    required: [options]
                     properties:
                       optional:
                         type: boolean
-                    oneOf:
-                    - type: object
-                      required: [options]
-                      properties:
-                        options:
-                          type: object
-                          required: [url]
-                          properties:
-                            url:
-                              type: string
-                              format: uri
-                    - type: object
-                      required: [options]
-                      properties:
-                        options:
-                          type: object
-                          required: [uri]
-                          properties:
-                            uri:
-                              type: string
-                              format: uri
-                    - type: object
-                      required: [url]
-                      properties:
-                        url:
-                          type: string
-                          format: uri
-                    - type: object
-                      required: [uri]
-                      properties:
-                        uri:
-                          type: string
-                          format: uri
+                      options:
+                        type: object
+                        oneOf:
+                          - required: [url]
+                          - required: [uri]
+                        properties:
+                          url:
+                            type: string
+                            format: uri
+                          uri:
+                            type: string
+                            format: uri


### PR DESCRIPTION
Allow for old non structural schema under deploy.razee.io/v1alpha1 and continues support the schema in the code as well as define the new structural schema under deploy.razee.io/v1alpha2 and also understand the new schema in the code.