### PR TITLE
Update: allow valueFrom secretKeyRef in request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ spec:
         headers:
           <header_key1>: <header_value1>
           <header_key2>: <header_value2>
+          <header_key3>:
+            valueFrom:
+              secretKeyRef:
+                name: <name of secret resource>
+                key: <key of secret>
     - optional: true
       options:
         url: http://<source_repo_url>/<file_name2>


### PR DESCRIPTION
closes: https://github.com/razee-io/Razee/issues/53

```
spec:
  requests:
  - options:
      url: https://api.github.com/repos/maire-kehoe/test-razee-private/contents/helloConfigMap.yml?ref=master
      headers:
        Authorization:
          valueFrom:
            secretKeyRef:
              name: hello-secret
              key: password
        Accept: application/vnd.github.VERSION.raw
        User-Agent: cluster-remoteresource-yml-github-agent
```